### PR TITLE
Fix password leak in logs

### DIFF
--- a/plugins/modules/redhat_csp_download.py
+++ b/plugins/modules/redhat_csp_download.py
@@ -105,7 +105,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             username=dict(required=True),
-            password=dict(no_log=False, required=True),
+            password=dict(no_log=True, required=True),
             url=dict(required=True),
             dest=dict(required=True)
         ),


### PR DESCRIPTION
Password parameter should be `no_log=True` to prevent password leak in ansible logs